### PR TITLE
Extend regex filtering for tmux remote policies

### DIFF
--- a/bin/workflow
+++ b/bin/workflow
@@ -2035,7 +2035,7 @@ sub _builtin_tmux_sessions
 	{
 	    my $remote_policy = $target_server->{remote_policy};
 
-	    $remote_policy =~ m(-t ([^\s]+));
+	    $remote_policy =~ m(-t ([^:\s]+)(:[^\s]+)?);
 
 	    my $tmux_session_name = $1;
 


### PR DESCRIPTION
Up until now, if a target used the following remote policy:

```
tmux send-keys -t my-session-name
```

The "my-session-name" would be filtered out by a regex in the engine. When the built-in "workflow-commands builtin tmux_create_sessions" is run, a "my-session-name" tmux session would be created.

The send-keys command above would sends the keys to whichever window is active. If the user is currently looking at window 2, where, for example, a QEMU shell is open, the keys will be sent there. This can cause problems when the user is actively using a tmux session, while using workflow commands at the same time.

However, the tmux send-keys command can also accept window names. For instance:

```
tmux send-keys -t my-session-name:0 blabla ENTER
```

The command above will send the "blabla" text specifically to window 0 in the "my-session-name" session.

This commit extends the regex filter in the engine, in order to make it easier to manage multi-window tmux sessions. Specifically, this commit filters out the colon, and whatever window names comes after it, to avoid creating sessions named "my-session-name:0".