### PR TITLE
workflow: create target directory if it doesn't exist

### DIFF
--- a/bin/workflow
+++ b/bin/workflow
@@ -2189,6 +2189,12 @@ sub _install_script_grc_symbolic_links
 
 	my $target_file_configuration = "$target_directory/$grc_configuration";
 
+	if (not -e $target_directory)
+	{
+		my $command = "mkdir -p $target_directory";
+		execute_shell_command($command, { sudo => 1, }, );
+	}
+
 	if ($option_verbose)
 	{
 	    use Data::Dumper;


### PR DESCRIPTION
This is the equivalent of https://github.com/HugoCornelis/developer/pull/1.
Please note that I haven't checked if it is still useful or relevant.

This fixes the following error message, raised when calling 'install_scripts' for the very first project:

ln: failed to create symbolic link '/usr/share/grc/conf.test_project-configuration': No such file or directory
/usr/local/bin/workflow: *** Fatal: sudo ln -sf /home/rme/projects/test/conf.test_project-configuration /usr/share/grc/conf.test_project-configuration failed with exit status 256

---

Note that these are my very first lines of perl code, so you might want to triple-check them.
